### PR TITLE
Removed exclusion of .classpath and .project from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,1 @@
 /bin/
-
-# remove classpath and project files
-.classpath
-.project

--- a/.project
+++ b/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>economic-sim</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>


### PR DESCRIPTION
When importing the project onto a new computer, I was getting several
errors, which I was able to reproduce regularly on two devices. If I
made a new project, deleted the files in it, and then pulled from
GitHub, I received an error, stating that the .project is missing. I
then restored it, and everything appears to be working properly.
